### PR TITLE
Add support for retrieving Tuple values by name with Storm 0.10.0+

### DIFF
--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -14,6 +14,7 @@ from traceback import format_exc
 
 from six import iteritems
 
+from .exceptions import StormWentAwayError
 from .serializers.msgpack_serializer import MsgpackSerializer
 from .serializers.json_serializer import JSONSerializer
 

--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -39,7 +39,8 @@ _PYTHON_LOG_LEVELS = {'critical': logging.CRITICAL,
                       'debug': logging.DEBUG,
                       'trace': logging.DEBUG}
 _SERIALIZERS = {"json": JSONSerializer, "msgpack": MsgpackSerializer}
-# Used for generating namedtuple type names
+# Convert names to valid Python identifiers by replacing non-word characters
+# whitespace and leading digits with underscores.
 _IDENTIFIER_RE = re.compile(r'\W|^(?=\d)')
 
 

--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -3,15 +3,17 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
+import re
 import signal
 import sys
-from collections import deque, namedtuple
+from collections import defaultdict, deque, namedtuple
 from logging.handlers import RotatingFileHandler
 from os.path import join
 from threading import RLock
 from traceback import format_exc
 
-from .exceptions import StormWentAwayError
+from six import iteritems
+
 from .serializers.msgpack_serializer import MsgpackSerializer
 from .serializers.json_serializer import JSONSerializer
 
@@ -36,6 +38,8 @@ _PYTHON_LOG_LEVELS = {'critical': logging.CRITICAL,
                       'debug': logging.DEBUG,
                       'trace': logging.DEBUG}
 _SERIALIZERS = {"json": JSONSerializer, "msgpack": MsgpackSerializer}
+# Used for generating namedtuple type names
+_IDENTIFIER_RE = re.compile(r'\W|^(?=\d)')
 
 
 log = logging.getLogger(__name__)
@@ -121,7 +125,7 @@ Tuple = namedtuple('Tuple', 'id component stream task values')
 :ivar task: the task the Tuple was generated from.
 :type task: int
 :ivar values: the payload of the Tuple where data is stored.
-:type values: list
+:type values: tuple (or namedtuple for Storm 0.10.0+)
 """
 
 
@@ -177,6 +181,7 @@ class Component(object):
         self.context = None
         self.pid = os.getpid()
         self.logger = None
+        self._source_tuple_types = defaultdict(dict)
         # pending commands/Tuples we read while trying to read task IDs
         self._pending_commands = deque()
         # pending task IDs we read while trying to read commands/Tuples
@@ -207,6 +212,15 @@ class Component(object):
         self.topology_name = storm_conf.get('topology.name', '')
         self.task_id = context.get('taskid', '')
         self.component_name = context.get('componentid')
+        # source->stream->fields requires Storm 0.10.0 or later
+        source_stream_fields = context.get('source->stream->fields', {})
+        for source, stream_fields in iteritems(source_stream_fields):
+            for stream, fields in iteritems(stream_fields):
+                type_name = (_IDENTIFIER_RE.sub('_', source.title()) +
+                             _IDENTIFIER_RE.sub('_', stream.title()) +
+                             'Tuple')
+                self._source_tuple_types[source][stream] = namedtuple(type_name,
+                                                                      fields)
         # If using Storm before 0.10.0 componentid is not available
         if self.component_name is None:
             self.component_name = context.get('task->component', {})\
@@ -280,8 +294,12 @@ class Component(object):
 
     def read_tuple(self):
         cmd = self.read_command()
-        return Tuple(cmd['id'], cmd['comp'], cmd['stream'], cmd['task'],
-                     cmd['tuple'])
+        source = cmd['comp']
+        stream = cmd['stream']
+        values = cmd['tuple']
+        val_type = self._source_tuple_types[source].get(stream)
+        return Tuple(cmd['id'], source, stream, cmd['task'],
+                     tuple(values) if val_type is None else val_type(*values))
 
     def read_handshake(self):
         """Read and process an initial handshake message from Storm."""

--- a/test/pystorm/test_bolt.py
+++ b/test/pystorm/test_bolt.py
@@ -201,7 +201,7 @@ class BoltTests(unittest.TestCase):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id=None, task=-1,
                                              component='__system',
-                                             stream='__tick', values=(50))
+                                             stream='__tick', values=(50,))
         self.bolt._run()
         process_tick_mock.assert_called_with(self.bolt,
                                              read_tuple_mock.return_value)
@@ -375,7 +375,7 @@ class BatchingBoltTests(unittest.TestCase):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id=None, task=-1,
                                              component='__system',
-                                             stream='__tick', values=(50))
+                                             stream='__tick', values=(50,))
         self.bolt._run()
         process_tick_mock.assert_called_with(self.bolt,
                                              read_tuple_mock.return_value)

--- a/test/pystorm/test_bolt.py
+++ b/test/pystorm/test_bolt.py
@@ -34,7 +34,7 @@ class BoltTests(unittest.TestCase):
         tup_json = "{}\nend\n".format(json.dumps(self.tup_dict)).encode('utf-8')
         self.tup = Tuple(self.tup_dict['id'], self.tup_dict['comp'],
                          self.tup_dict['stream'], self.tup_dict['task'],
-                         self.tup_dict['tuple'],)
+                         tuple(self.tup_dict['tuple']),)
         self.bolt = Bolt(input_stream=BytesIO(tup_json),
                          output_stream=BytesIO())
         self.bolt.initialize({}, {})
@@ -190,7 +190,7 @@ class BoltTests(unittest.TestCase):
     def test_heartbeat_response(self, send_message_mock, read_tuple_mock):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id='foo', task=-1,
-                                             stream='__heartbeat', values=[],
+                                             stream='__heartbeat', values=(),
                                              component='__system')
         self.bolt._run()
         send_message_mock.assert_called_with(self.bolt, {'command': 'sync'})
@@ -201,7 +201,7 @@ class BoltTests(unittest.TestCase):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id=None, task=-1,
                                              component='__system',
-                                             stream='__tick', values=[50])
+                                             stream='__tick', values=(50))
         self.bolt._run()
         process_tick_mock.assert_called_with(self.bolt,
                                              read_tuple_mock.return_value)
@@ -239,8 +239,8 @@ class BatchingBoltTests(unittest.TestCase):
         tups_json = '\nend\n'.join([json.dumps(tup_dict) for tup_dict in
                                     self.tup_dicts] + [''])
         self.tups = [Tuple(tup_dict['id'], tup_dict['comp'], tup_dict['stream'],
-                           tup_dict['task'], tup_dict['tuple']) for tup_dict in
-                     self.tup_dicts]
+                           tup_dict['task'], tuple(tup_dict['tuple']))
+                     for tup_dict in self.tup_dicts]
         self.nontick_tups = [tup for tup in self.tups if tup.stream != '__tick']
         self.bolt = BatchingBolt(input_stream=BytesIO(tups_json.encode('utf-8')),
                                  output_stream=BytesIO())
@@ -364,7 +364,7 @@ class BatchingBoltTests(unittest.TestCase):
     def test_heartbeat_response(self, send_message_mock, read_tuple_mock):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id='foo', task=-1,
-                                             stream='__heartbeat', values=[],
+                                             stream='__heartbeat', values=(),
                                              component='__system')
         self.bolt._run()
         send_message_mock.assert_called_with(self.bolt, {'command': 'sync'})
@@ -375,7 +375,7 @@ class BatchingBoltTests(unittest.TestCase):
         # Make sure we send sync for heartbeats
         read_tuple_mock.return_value = Tuple(id=None, task=-1,
                                              component='__system',
-                                             stream='__tick', values=[50])
+                                             stream='__tick', values=(50))
         self.bolt._run()
         process_tick_mock.assert_called_with(self.bolt,
                                              read_tuple_mock.return_value)


### PR DESCRIPTION
This fixes #9 and lets people do awesome things like `tup.values.word` to access the field named `word` contained in the tuple.  `tup.values[0]` is still supported, since it uses a `namedtuple` underneath.