### PR TITLE
Add output_fields and streams properties to Component class.

### DIFF
--- a/pystorm/bolt.py
+++ b/pystorm/bolt.py
@@ -42,6 +42,14 @@ class Bolt(Component):
     :ivar auto_fail: A ``bool`` indicating whether or not the bolt should
                      automatically fail Tuples when an exception occurs when the
                      ``process()`` method is called. Default is ``True``.
+    :ivar output_fields: Either a ``list`` of field names to be used for the
+                         Tuples emitted on the default stream of this component,
+                         or a ``dict`` mapping from stream names to the lists of
+                         field names for Tuples emitted on those streams.
+
+                         .. note::
+                           This is implemented as a property, so when reading,
+                           it will always return a dictionary, and not a list.
 
     **Example**:
 
@@ -50,6 +58,7 @@ class Bolt(Component):
         from pystorm.bolt import Bolt
 
         class SentenceSplitterBolt(Bolt):
+            output_fields = ['word']
 
             def process(self, tup):
                 sentence = tup.values[0]

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -20,6 +20,15 @@ class Spout(Component):
 
     For more information on spouts, consult Storm's
     `Concepts documentation <http://storm.apache.org/documentation/Concepts.html>`_.
+
+    :ivar output_fields: Either a ``list`` of field names to be used for the
+                         Tuples emitted on the default stream of this component,
+                         or a ``dict`` mapping from stream names to the lists of
+                         field names for Tuples emitted on those streams.
+
+                         .. note::
+                           This is implemented as a property, so when reading,
+                           it will always return a dictionary, and not a list.
     """
 
     def ack(self, tup_id):

--- a/test/pystorm/test_component.py
+++ b/test/pystorm/test_component.py
@@ -78,22 +78,27 @@ class ComponentTests(unittest.TestCase):
         pid_path = os.path.join(pid_dir, str(component.pid))
         self.assertTrue(os.path.exists(pid_path))
         os.remove(pid_path)
-        self.assertEqual(given_conf, expected_conf)
-        self.assertEqual(given_context, expected_context)
+        self.assertDictEqual(given_conf, expected_conf)
+        self.assertDictEqual(given_context, expected_context)
         self.assertEqual(component.serializer.serialize_dict({"pid": component.pid}).encode('utf-8'),
                          component.serializer.output_stream.buffer.getvalue())
 
     def test_setup_component(self):
         conf = self.conf
+        context = self.context
         component = Component(input_stream=BytesIO(),
                               output_stream=BytesIO())
-        component._setup_component(conf, self.context)
+        component._setup_component(conf, context)
         self.assertEqual(component.topology_name, conf['topology.name'])
-        self.assertEqual(component.task_id, self.context['taskid'])
+        self.assertEqual(component.task_id, context['taskid'])
         self.assertEqual(component.component_name,
-                         self.context['task->component'][str(self.context['taskid'])])
-        self.assertEqual(component.storm_conf, conf)
-        self.assertEqual(component.context, self.context)
+                         context['task->component'][str(context['taskid'])])
+        self.assertDictEqual(component.storm_conf, conf)
+        self.assertDictEqual(component.context, context)
+        self.assertDictEqual(component.output_fields,
+                             context['stream->outputfields'])
+        self.assertSequenceEqual(component.streams,
+                                 context['stream->outputfields'].keys())
 
     def test_read_message(self):
         inputs = [# Task IDs


### PR DESCRIPTION
With Storm 0.10.0+, these will be pulled out from the context sent as part of
the multilang handshake.

`output_fields` can also be set when a component is being defined for use in
a Python-based topology DSL, like we're adding to streamparse.