### PR TITLE
Add exit_on_exception flag to Component class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _release/
 _resources/
 *.sw*
 .tox/
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
 python:
   - "2.7"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ python:
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install python-coveralls coverage pytest-cov
+  - travis_retry pip install python-coveralls coverage pytest-cov pytest-timeout
   - echo TRAVIS_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} != "3" ]; then travis_retry pip install contextlib2; fi
   - python setup.py --version
 
 # Run test
 script:
-  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then py.test --cov=pystorm --cov-config .coveragerc; fi
-  - if [ $TRAVIS_PYTHON_VERSION != "3.4" ]; then py.test; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then py.test --cov=pystorm --cov-config .coveragerc --timeout=10; fi
+  - if [ $TRAVIS_PYTHON_VERSION != "3.4" ]; then py.test --timeout=10; fi
 
 # Calculate coverage on success
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 sudo: false
-cache:
-  directories:
-    - $HOME/.cache/pip
 python:
   - "2.7"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
   - "pypy"
 
 install:
+  - travis_retry pip install --upgrade pip
+  - travis_retry pip install --upgrade pytest python-coveralls coverage pytest-cov pytest-timeout
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest python-coveralls coverage pytest-cov pytest-timeout
   - echo TRAVIS_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} != "3" ]; then travis_retry pip install contextlib2; fi
   - python setup.py --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install python-coveralls coverage pytest-cov pytest-timeout
+  - travis_retry pip install pytest python-coveralls coverage pytest-cov pytest-timeout
   - echo TRAVIS_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} != "3" ]; then travis_retry pip install contextlib2; fi
   - python setup.py --version

--- a/pystorm/version.py
+++ b/pystorm/version.py
@@ -29,5 +29,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = '1.1.0.dev'
+__version__ = '1.1.0.dev0'
 VERSION = tuple(_safe_int(x) for x in __version__.split('.'))

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ lint_requires = [
     'pyflakes'
 ]
 
+tests_require = ['pytest', 'pytest-timeout']
+
 if sys.version_info.major < 3:
-    tests_require = ['mock', 'pytest', 'unittest2']
-else:
-    tests_require = ['mock', 'pytest']
+    tests_require.append('mock')
 
 dependency_links = []
 setup_requires = []


### PR DESCRIPTION
This fixes #16 and allows us to just fail tuples when an exception is raised instead of killing the whole process.

`StormWentAwayError` will still cause an exit, because there's no point in continuing without Storm.

This PR also starts using `pytest-timeout` and the `--timeout` parameter for running tests on Travis so we don't get stuck when tests hang.  When I was working on this I broke the tests in hanging ways a few times and it was incredibly frustrating.

Another unit testing improvement is that we do not override `sys.stdout` when `output_stream` is not set to `sys.stdout` anymore, because that was pointless and made debugging tests really hard.