### PR TITLE
Remove deprecated Spout.emit_many method

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -67,7 +67,7 @@ Now let's create a bolt that takes in sentences, and spits out words:
                 return
 
             for word in words:
-                self.emit(word)
+                self.emit([word])
             # tuple acknowledgement is handled automatically
 
 The bolt implementation is even simpler. We simply override the default

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -76,10 +76,6 @@ an incoming spout or bolt. You are welcome to do whatever processing you would
 like in this method and can further emit tuples or not depending on the purpose
 of your bolt.
 
-In the ``SentenceSplitterBolt`` above, we have decided to use the
-``emit_many()`` method instead of ``emit()`` which is a bit more efficient when
-sending a larger number of tuples to Storm.
-
 If your ``process()`` method completes without raising an Exception, pystorm
 will automatically ensure any emits you have are anchored to the current tuple
 being processed and acknowledged after ``process()`` completes.

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -83,48 +83,6 @@ class Spout(Component):
                                        direct_task=direct_task,
                                        need_task_ids=need_task_ids)
 
-    def emit_many(self, tuples, stream=None, tup_ids=None, direct_task=None,
-                  need_task_ids=True):
-        """Emit multiple tuples.
-
-        :param tuples: a ``list`` of multiple Tuple payloads to send to
-                       Storm. All Tuples should contain only
-                       JSON-serializable data.
-        :type tuples: list
-        :param stream: the ID of the stream to emit these Tuples to. Specify
-                       ``None`` to emit to default stream.
-        :type stream: str
-        :param tup_ids: the ID for the Tuple. Leave this blank for an
-                       unreliable emit.
-        :type tup_ids: list
-        :param tup_ids: IDs for each of the Tuples in the list.  Omit these for
-                        an unreliable emit.
-        :type anchors: list
-        :param direct_task: indicates the task to send the Tuple to.
-        :type direct_task: int
-        :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the Tuple was emitted (default:
-                              ``True``).
-        :type need_task_ids: bool
-
-        .. deprecated:: 2.0.0
-            Just call :py:meth:`Spout.emit` repeatedly instead.
-        """
-        if not isinstance(tuples, (list, tuple)):
-            raise TypeError('Tuples should be a list of lists/tuples, '
-                            'received {!r} instead.'.format(type(tuples)))
-
-        all_task_ids = []
-        if tup_ids is None:
-            tup_ids = itertools.repeat(None)
-
-        for tup, tup_id in zip(tuples, tup_ids):
-            all_task_ids.append(self.emit(tup, stream=stream, tup_id=tup_id,
-                                          direct_task=direct_task,
-                                          need_task_ids=need_task_ids))
-
-        return all_task_ids
-
     def _run(self):
         """The inside of ``run``'s infinite loop.
 


### PR DESCRIPTION
Not sure how this has survived so long.