### PR TITLE
Support for custom log filenames based on pystorm.log.file setting.

### DIFF
--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -226,10 +226,10 @@ class Component(object):
                                                   self.component_name)))
         log_path = self.storm_conf.get('pystorm.log.path')
         log_file_name = self.storm_conf.get('pystorm.log.file',
-                                            'pystorm_{d[topology_name]}'
-                                            '_{d[component_name]}'
-                                            '_{d[task_id]}'
-                                            '_{d[pid]}.log')
+                                            'pystorm_{topology_name}'
+                                            '_{component_name}'
+                                            '_{task_id}'
+                                            '_{pid}.log')
         if log_path:
             root_log = logging.getLogger()
             max_bytes = self.storm_conf.get('pystorm.log.max_bytes',
@@ -238,10 +238,10 @@ class Component(object):
                                                10)
             log_file = join(log_path,
                             (log_file_name
-                             .format(d=dict(topology_name=self.topology_name,
+                             .format(topology_name=self.topology_name,
                                      component_name=self.component_name,
                                      task_id=self.task_id,
-                                     pid=self.pid))))
+                                     pid=self.pid)))
             handler = RotatingFileHandler(log_file, maxBytes=max_bytes,
                                           backupCount=backup_count)
             formatter = logging.Formatter('%(asctime)s - %(name)s - '

--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -225,6 +225,11 @@ class Component(object):
         self.logger = logging.getLogger('.'.join((__name__,
                                                   self.component_name)))
         log_path = self.storm_conf.get('pystorm.log.path')
+        log_file_name = self.storm_conf.get('pystorm.log.file',
+                                            'pystorm_{d[topology_name]}'
+                                            '_{d[component_name]}'
+                                            '_{d[task_id]}'
+                                            '_{d[pid]}.log')
         if log_path:
             root_log = logging.getLogger()
             max_bytes = self.storm_conf.get('pystorm.log.max_bytes',
@@ -232,12 +237,11 @@ class Component(object):
             backup_count = self.storm_conf.get('pystorm.log.backup_count',
                                                10)
             log_file = join(log_path,
-                            ('pystorm_{topology_name}_{component_name}'
-                             '_{task_id}_{pid}.log'
-                             .format(topology_name=self.topology_name,
+                            (log_file_name
+                             .format(d=dict(topology_name=self.topology_name,
                                      component_name=self.component_name,
                                      task_id=self.task_id,
-                                     pid=self.pid)))
+                                     pid=self.pid))))
             handler = RotatingFileHandler(log_file, maxBytes=max_bytes,
                                           backupCount=backup_count)
             formatter = logging.Formatter('%(asctime)s - %(name)s - '


### PR DESCRIPTION
This commit adds support for custom log filenames. Due to the usage of a dict as a placeholder you now don't have to use all placeholders such as `topology_name`, `pid`, etc.. if you don't want to.
The default value has been set to the old, hardcoded value.

Signed-off-by: Kalman Olah <kalman@inuits.eu>