### PR TITLE
Make need_task_ids default to False to speed things up

### DIFF
--- a/pystorm/bolt.py
+++ b/pystorm/bolt.py
@@ -128,7 +128,7 @@ class Bolt(Component):
         pass
 
     def emit(self, tup, stream=None, anchors=None, direct_task=None,
-             need_task_ids=True):
+             need_task_ids=False):
         """Emit a new Tuple to a stream.
 
         :param tup: the Tuple payload to send to Storm, should contain only
@@ -146,13 +146,13 @@ class Bolt(Component):
         :param direct_task: the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the Tuple was emitted (default: ``True``).
+                              the Tuple was emitted (default: ``False``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
-                  when specifying direct_task, this will be equal to
-                  ``[direct_task]``. If you specify ``need_task_ids=False``,
-                  this function will return ``None``.
+        :returns: ``None``, unless ``need_task_ids=True``, in which case it will
+                  be a ``list`` of task IDs that the Tuple was sent to if. Note
+                  that when specifying direct_task, this will be equal to
+                  ``[direct_task]``.
         """
         if anchors is None:
             anchors = self._current_tups if self.auto_anchor else []

--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -364,7 +364,7 @@ class Component(object):
                            'level': level})
 
     def emit(self, tup, tup_id=None, stream=None, anchors=None,
-             direct_task=None, need_task_ids=True):
+             direct_task=None, need_task_ids=False):
         """Emit a new Tuple to a stream.
 
         :param tup: the Tuple payload to send to Storm, should contain only
@@ -385,13 +385,13 @@ class Component(object):
         :param direct_task: the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the Tuple was emitted (default: ``True``).
+                              the Tuple was emitted (default: ``False``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
-                  when specifying direct_task, this will be equal to
-                  ``[direct_task]``. If you specify ``need_task_ids=False``,
-                  this function will return ``None``.
+        :returns: ``None``, unless ``need_task_ids=True``, in which case it will
+                  be a ``list`` of task IDs that the Tuple was sent to if. Note
+                  that when specifying direct_task, this will be equal to
+                  ``[direct_task]``.
         """
         if not isinstance(tup, (list, tuple)):
             raise TypeError('All Tuples must be either lists or tuples, '

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -54,7 +54,7 @@ class Spout(Component):
         raise NotImplementedError()
 
     def emit(self, tup, tup_id=None, stream=None, direct_task=None,
-             need_task_ids=True):
+             need_task_ids=False):
         """Emit a spout Tuple message.
 
         :param tup: the Tuple to send to Storm, should contain only
@@ -70,14 +70,13 @@ class Spout(Component):
                             direct emit.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the Tuple was emitted (default:
-                              ``True``).
+                              the Tuple was emitted (default: ``False``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
-                  when specifying direct_task, this will be equal to
-                  ``[direct_task]``. If you specify ``need_task_ids=False``,
-                  this function will return ``None``.
+        :returns: ``None``, unless ``need_task_ids=True``, in which case it will
+                  be a ``list`` of task IDs that the Tuple was sent to if. Note
+                  that when specifying direct_task, this will be equal to
+                  ``[direct_task]``.
         """
         return super(Spout, self).emit(tup, tup_id=tup_id, stream=stream,
                                        direct_task=direct_task,

--- a/test/pystorm/test_bolt.py
+++ b/test/pystorm/test_bolt.py
@@ -110,7 +110,8 @@ class BoltTests(unittest.TestCase):
         send_message_mock.assert_called_with(self.bolt, {'command': 'emit',
                                                          'anchors': [],
                                                          'tuple': [1, 2, 3],
-                                                         'task': 'other_bolt'})
+                                                         'task': 'other_bolt',
+                                                         'need_task_ids': False})
 
     @patch.object(Bolt, 'send_message', autospec=True)
     def test_ack_id(self, send_message_mock):

--- a/test/pystorm/test_spout.py
+++ b/test/pystorm/test_spout.py
@@ -49,7 +49,8 @@ class SpoutTests(unittest.TestCase):
         self.spout.emit([1, 2, 3], direct_task='other_spout')
         send_message_mock.assert_called_with(self.spout, {'command': 'emit',
                                                           'tuple': [1, 2, 3],
-                                                          'task': 'other_spout'})
+                                                          'task': 'other_spout',
+                                                          'need_task_ids': False})
         # Reliable emit
         self.spout.emit([1, 2, 3], tup_id='foo', need_task_ids=False)
         send_message_mock.assert_called_with(self.spout, {'command': 'emit',
@@ -62,7 +63,8 @@ class SpoutTests(unittest.TestCase):
         send_message_mock.assert_called_with(self.spout, {'command': 'emit',
                                                           'tuple': [1, 2, 3],
                                                           'task': 'other_spout',
-                                                          'id': 'foo'})
+                                                          'id': 'foo',
+                                                          'need_task_ids': False})
 
     @patch.object(Spout, 'read_command', autospec=True,
                   return_value={'command': 'ack', 'id': 1234})


### PR DESCRIPTION
This closes #29.

We will release new major version because this a backward incompatible change.