### PR TITLE
Make StormHandler the default unless pystorm.log.path is set in Storm settings

### DIFF
--- a/pystorm/__init__.py
+++ b/pystorm/__init__.py
@@ -1,6 +1,13 @@
+'''
+pystorm is a production-tested Storm multi-lang implementation for Python
+
+It is mostly intended to be used by other libraries (e.g., streamparse).
+'''
+
 from .component import Component, Tuple
 from .bolt import BatchingBolt, Bolt, TicklessBatchingBolt
 from .spout import Spout
+from .version import __version__, VERSION
 
 __all__ = [
     'BatchingBolt',


### PR DESCRIPTION
This will make it much easier for people to log things directly to Storm, where logs will be much more readily searchable in Storm 1.0+.