### PR TITLE
Fix a couple logging-related issues

### DIFF
--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -268,6 +268,7 @@ class Component(object):
         handler.setFormatter(formatter)
         root_log.addHandler(handler)
         self.logger.setLevel(log_level)
+        logging.getLogger('pystorm').setLevel(log_level)
         # Redirect stdout to ensure that print statements/functions
         # won't disrupt the multilang protocol
         if self.serializer.output_stream == sys.stdout:

--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -312,8 +312,9 @@ class Component(object):
     def send_message(self, message):
         """Send a message to Storm via stdout."""
         if not isinstance(message, dict):
-            log.error("%s.%d attempted to send a non dict message to Storm: %r",
-                       self.component_name, self.pid, message)
+            logger = self.logger if self.logger else log
+            logger.error("%s.%d attempted to send a non dict message to Storm: "
+                         "%r", self.component_name, self.pid, message)
             return
         self.serializer.send_message(message)
 

--- a/pystorm/serializers/serializer.py
+++ b/pystorm/serializers/serializer.py
@@ -4,7 +4,12 @@ each serializer a Java counterpart needs to exist.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
+
 from ..exceptions import StormWentAwayError
+
+
+log = logging.getLogger(__name__)
 
 
 class Serializer(object):
@@ -29,6 +34,8 @@ class Serializer(object):
                 self.output_stream.flush()
             except IOError:
                 raise StormWentAwayError()
+            except:
+                log.exception('Failed to send message: %r', msg_dict)
 
     def serialize_dict(self, msg_dict):
         """Convert a message dictionary to bytes.  Used by send_message"""

--- a/test/pystorm/serializers/test_json_serializer.py
+++ b/test/pystorm/serializers/test_json_serializer.py
@@ -44,3 +44,10 @@ class TestJSONSerializer(SerializerTestCase):
         self.instance.output_stream = string_io_mock
         with pytest.raises(StormWentAwayError):
             self.instance.send_message({'hello': "world",})
+
+    @mock.patch('pystorm.serializers.serializer.log.exception', autospec=True)
+    def test_send_message_bad_value(self, log_mock):
+        msg_dict = {'hello': b'\xfc\x89'}
+        self.instance.output_stream = StringIO()
+        self.instance.send_message(msg_dict)
+        log_mock.assert_called_with('Failed to send message: %r', msg_dict)


### PR DESCRIPTION
-  Catch serialization exceptions when sending messages
-  Use `Component.logger` if its set when `Component.send_message` is passed something that isn't a `dict`.
-  Set pystorm logger level so module-level logging will follow settings