### PR TITLE
Fix issue where namedtuples would be serialized as dicts and crash Storm workers

### DIFF
--- a/pystorm/serializers/json_serializer.py
+++ b/pystorm/serializers/json_serializer.py
@@ -90,7 +90,7 @@ class JSONSerializer(Serializer):
 
     def serialize_dict(self, msg_dict):
         """Serialize to JSON a message dictionary."""
-        serialized = json.dumps(msg_dict)
+        serialized = json.dumps(msg_dict, namedtuple_as_object=False)
         if PY2:
             serialized = serialized.decode('utf-8')
         serialized = '{}\nend\n'.format(serialized)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six>=1.5
 setuptools
-simplejson
+simplejson>=2.2.0
 msgpack-python

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def readme():
 
 install_requires = [
     'six>=1.5',
-    'simplejson',
+    'simplejson>=2.2.0',
     'msgpack-python'
 ]
 


### PR DESCRIPTION
Without this fix, if you tried to emit `tup.values` on Storm 0.10+, you would crash Storm because it is expecting the dictionary to contain a key called `'tuple'` with a `list` value.