### PR TITLE
Add ReliableSpout class

### DIFF
--- a/pystorm/__init__.py
+++ b/pystorm/__init__.py
@@ -6,13 +6,14 @@ It is mostly intended to be used by other libraries (e.g., streamparse).
 
 from .component import Component, Tuple
 from .bolt import BatchingBolt, Bolt, TicklessBatchingBolt
-from .spout import Spout
+from .spout import ReliableSpout, Spout
 from .version import __version__, VERSION
 
 __all__ = [
     'BatchingBolt',
     'Bolt',
     'Component',
+    'ReliableSpout',
     'Spout',
     'TicklessBatchingBolt',
     'Tuple',

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -161,6 +161,6 @@ class ReliableSpout(Component):
                              'tracked.')
         args = (tup, stream, direct_task, need_task_ids)
         self.unacked_tuples[tup_id] = args
-        super(ReliableSpout, self).emit(tup, tup_id=tup_id, stream=stream,
-                                        direct_task=direct_task,
-                                        need_task_ids=need_task_ids)
+        return super(ReliableSpout, self).emit(tup, tup_id=tup_id, stream=stream,
+                                               direct_task=direct_task,
+                                               need_task_ids=need_task_ids)

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -115,11 +115,10 @@ class ReliableSpout(Component):
                        the topology.
         :type tup_id: str
         """
-        if tup_id in self.failed_tuples:
-            del self.failed_tuples[tup_id]
-        if tup_id in self.unacked_tuples:
+        self.failed_tuples.pop(tup_id, None)
+        try:
             del self.unacked_tuples[tup_id]
-        else:
+        except KeyError:
             self.logger.error('Received ack for unknown tuple ID: %r', tup_id)
 
     def fail(self, tup_id):

--- a/pystorm/spout.py
+++ b/pystorm/spout.py
@@ -4,15 +4,9 @@ Base Spout classes.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-import itertools
-import logging
-
-from six.moves import zip
+from collections import Counter
 
 from .component import Component
-
-
-log = logging.getLogger(__name__)
 
 
 class Spout(Component):
@@ -97,3 +91,76 @@ class Spout(Component):
         else:
             self.logger.error('Received invalid command from Storm: %r', cmd)
         self.send_message({'command': 'sync'})
+
+
+class ReliableSpout(Component):
+    """Reliable spout that will automatically replay failed tuples.
+
+    Failed tuples will be replayed up to ``max_fails`` times.
+
+    For more information on spouts, consult Storm's
+    `Concepts documentation <http://storm.apache.org/documentation/Concepts.html>`_.
+    """
+    max_fails = 3
+
+    def __init__(self, *args, **kwargs):
+        super(ReliableSpout, self).__init__(*args, **kwargs)
+        self.failed_tuples = Counter()
+        self.unacked_tuples = {}
+
+    def ack(self, tup_id):
+        """Called when a bolt acknowledges a Tuple in the topology.
+
+        :param tup_id: the ID of the Tuple that has been fully acknowledged in
+                       the topology.
+        :type tup_id: str
+        """
+        if tup_id in self.failed_tuples:
+            del self.failed_tuples[tup_id]
+        if tup_id in self.unacked_tuples:
+            del self.unacked_tuples[tup_id]
+        else:
+            self.logger.error('Received ack for unknown tuple ID: %r', tup_id)
+
+    def fail(self, tup_id):
+        """Called when a Tuple fails in the topology
+
+        A reliable spout will replay a failed tuple up to ``max_fails`` times.
+
+        :param tup_id: the ID of the Tuple that has failed in the topology
+                       either due to a bolt calling ``fail()`` or a Tuple
+                       timing out.
+        :type tup_id: str
+        """
+        saved_args = self.unacked_tuples.get(tup_id)
+        if saved_args is None:
+            self.logger.error('Received fail for unknown tuple ID: %r', tup_id)
+            return
+        tup, stream, direct_task, need_task_ids = saved_args
+        if self.failed_tuples[tup_id] < self.max_fails:
+            self.emit(tup, tup_id=tup_id, stream=stream,
+                      direct_task=direct_task, need_task_ids=need_task_ids)
+            self.failed_tuples[tup_id] += 1
+        else:
+            # Just pretend we got an ack when we exceed retry limit
+            self.logger.info('Acking tuple ID %r after it exceeded retry limit '
+                             '(%r)', tup_id, self.max_fails)
+            self.ack(tup_id)
+
+    def emit(self, tup, tup_id=None, stream=None, direct_task=None,
+             need_task_ids=False):
+        """Emit a spout Tuple & add metadata about it to `unacked_tuples`.
+
+        In order for this to work, `tup_id` is a required parameter.
+
+        See :meth:`Bolt.emit`.
+        """
+        if tup_id is None:
+            raise ValueError('You must provide a tuple ID when emitting with a '
+                             'ReliableSpout in order for the tuple to be '
+                             'tracked.')
+        args = (tup, stream, direct_task, need_task_ids)
+        self.unacked_tuples[tup_id] = args
+        super(ReliableSpout, self).emit(tup, tup_id=tup_id, stream=stream,
+                                        direct_task=direct_task,
+                                        need_task_ids=need_task_ids)

--- a/test/pystorm/test_spout.py
+++ b/test/pystorm/test_spout.py
@@ -9,16 +9,11 @@ import unittest
 from io import BytesIO
 
 try:
-    from unittest import mock
     from unittest.mock import patch
 except ImportError:
-    import mock
     from mock import patch
 
-from pystorm import Spout, Tuple
-
-
-log = logging.getLogger(__name__)
+from pystorm import ReliableSpout, Spout, Tuple
 
 
 class SpoutTests(unittest.TestCase):
@@ -35,7 +30,7 @@ class SpoutTests(unittest.TestCase):
         self.spout = Spout(input_stream=BytesIO(),
                            output_stream=BytesIO())
         self.spout.initialize({}, {})
-        self.spout.logger = log
+        self.spout.logger = logging.getLogger(__name__)
 
     @patch.object(Spout, 'send_message', autospec=True)
     def test_emit(self, send_message_mock):
@@ -91,6 +86,84 @@ class SpoutTests(unittest.TestCase):
         self.spout._run()
         read_command_mock.assert_called_with(self.spout)
         self.assertEqual(next_tuple_mock.call_count, 1)
+
+
+class ReliableSpoutTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tup_dict = {'id': 14,
+                         'comp': 'some_spout',
+                         'stream': 'default',
+                         'task': 'some_spout',
+                         'tuple': [1, 2, 3]}
+        self.tup = Tuple(self.tup_dict['id'], self.tup_dict['comp'],
+                         self.tup_dict['stream'], self.tup_dict['task'],
+                         self.tup_dict['tuple'],)
+        self.spout = ReliableSpout(input_stream=BytesIO(),
+                                   output_stream=BytesIO())
+        self.spout.initialize({}, {})
+        self.spout.logger = logging.getLogger(__name__)
+
+    @patch.object(ReliableSpout, 'send_message', autospec=True)
+    def test_emit_unreliable(self, send_message_mock):
+        # An unreliable emit is not allowed with ReliableSpout
+        with self.assertRaises(ValueError):
+            self.spout.emit([1, 2, 3], need_task_ids=False)
+
+    @patch.object(ReliableSpout, 'send_message', autospec=True)
+    def test_emit_reliable(self, send_message_mock):
+        # Reliable emit
+        self.spout.emit([1, 2, 3], tup_id='foo', need_task_ids=False)
+        send_message_mock.assert_called_with(self.spout, {'command': 'emit',
+                                                          'tuple': [1, 2, 3],
+                                                          'need_task_ids': False,
+                                                          'id': 'foo'})
+        self.assertEqual(self.spout.unacked_tuples.get('foo'),
+                         ([1, 2, 3], None, None, False))
+
+    @patch.object(ReliableSpout, 'send_message', autospec=True)
+    def test_emit_reliable_direct(self, send_message_mock):
+        # Reliable emit as direct task
+        self.spout.emit([1, 2, 3], tup_id='foo', direct_task='other_spout')
+        send_message_mock.assert_called_with(self.spout, {'command': 'emit',
+                                                          'tuple': [1, 2, 3],
+                                                          'task': 'other_spout',
+                                                          'id': 'foo',
+                                                          'need_task_ids': False})
+        self.assertEqual(self.spout.unacked_tuples.get('foo'),
+                         ([1, 2, 3], None, 'other_spout', False))
+
+    def test_ack(self):
+        self.spout.failed_tuples['foo'] = 2
+        self.spout.unacked_tuples['foo'] = ([1, 2, 3], None, None, True)
+        # Make sure ack cleans up failed_tuples and unacked_tuples
+        self.spout.ack('foo')
+        self.assertNotIn('foo', self.spout.failed_tuples)
+        self.assertNotIn('foo', self.spout.unacked_tuples)
+
+    @patch.object(ReliableSpout, 'emit', autospec=True)
+    def test_fail_below_limit(self, emit_mock):
+        # Make sure fail increments failed_tuples and calls emit
+        self.spout.max_fails = 3
+        self.spout.failed_tuples['foo'] = 2
+        self.spout.unacked_tuples['foo'] = ([1, 2, 3], None, None, True)
+        self.spout.fail('foo')
+        self.assertEqual(self.spout.failed_tuples['foo'], 3)
+        emit_mock.assert_called_with(self.spout, [1, 2, 3], direct_task=None,
+                                     need_task_ids=True, stream=None,
+                                     tup_id='foo')
+
+    @patch.object(ReliableSpout, 'ack', autospec=True)
+    @patch.object(ReliableSpout, 'emit', autospec=True)
+    def test_fail_above_limit(self, emit_mock, ack_mock):
+        # Make sure fail increments failed_tuples
+        self.spout.max_fails = 3
+        self.spout.failed_tuples['foo'] = 3
+        emit_args = ([1, 2, 3], None, None, True)
+        self.spout.unacked_tuples['foo'] = emit_args
+        self.spout.fail('foo')
+        self.assertEqual(emit_mock.call_count, 0)
+        ack_mock.assert_called_with(self.spout, 'foo')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This spout keeps track of which tuples have been emitted and replays upon failure. There is probably a more memory efficient way to do this, but it was a simple way that popped into my head.