### PR TITLE
[FIX] Signal with SIGTERM on Windows.

### DIFF
--- a/pystorm/component.py
+++ b/pystorm/component.py
@@ -205,6 +205,8 @@ class Component(object):
         if isinstance(rdb_signal, string_types) and hasattr(signal,
                                                             rdb_signal):
             rdb_signal = getattr(signal, rdb_signal)
+        else:
+            rdb_signal = getattr(signal, 'SIGTERM')
 
         # Setup remote pdb handler if asked to
         if rdb_signal is not None:


### PR DESCRIPTION
When running directly within Storm on Windows the error _TypeError: an integer is required (got type str)_ is thrown when attempting to convert the signal to an enum value. This fix is a workaround signal that is sent when SIGUSR1 is not supported.