### PR TITLE
Replace `msgpack-python` package with `msgpack`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six>=1.5
 setuptools
 simplejson>=2.2.0
-msgpack-python
+msgpack

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def readme():
 install_requires = [
     'six>=1.5',
     'simplejson>=2.2.0',
-    'msgpack-python'
+    'msgpack'
 ]
 
 if sys.version_info.major < 3:


### PR DESCRIPTION
According to https://pypi.python.org/pypi/msgpack-python, this package is now deprecated and should be replaced with `msgpack`.

At the time of writing, any new versions are published under both names, but that's not guaranteed to be the case in the future.