### PR TITLE
TicklessBatchingBolt: Fix handling exit_on_exception=False

### DIFF
--- a/pystorm/bolt.py
+++ b/pystorm/bolt.py
@@ -504,12 +504,12 @@ class TicklessBatchingBolt(BatchingBolt):
 
     def _batch_entry(self):
         """Entry point for the batcher thread."""
-        try:
-            while True:
+        while True:
+            try:
                 self._batch_entry_run()
-        except:
-            self.exc_info = sys.exc_info()
-            os.kill(self.pid, signal.SIGUSR1)  # interrupt stdin waiting
+            except:
+                self.exc_info = sys.exc_info()
+                os.kill(self.pid, signal.SIGUSR1)  # interrupt stdin waiting
 
     def _handle_worker_exception(self, signum, frame):
         """Handle an exception raised in the worker thread.


### PR DESCRIPTION
This PR fixes a bug in `TicklessBatchingBolt` when `exit_on_exception` is `False`.

Currently, when an exception occurs inside `process_batch()`, the `_batch_entry` thread exits regardless of `exit_on_exception` setting. The try/except block in `_batch_entry` wraps the loop, so the thread exits cleanly after the exception is caught, without crashing or logging further errors. Meanwhile, the main thread continues accepting and grouping tuples. Since the batching thread has stopped processing, these accumulated batches are never processed or cleared, leading to stalled topologies.

Setting `exit_on_exception=False` suggests that processing should continue after error handling, but instead it hangs indefinitely.

This change moves the try/except inside the loop body, so that the batching thread keeps running and processing batches. This makes it so that the transient errors do not permanently halt batch processing.

When `exit_on_exception` is set to `True`, the parent thread should still be able to kill the processing thread while handling the exception: https://github.com/pystorm/pystorm/blob/master/pystorm/component.py#L544-L550

I wrote a short script to showcase the bug: [gist](https://gist.github.com/trakos/f17ab685d914349ff1ed498ccd754cfd). Without this PR, the script will stop processing the tuples after the first exception, and it will instead only accept new tuples and continuously output `Batcher thread has exited`. With this change, it should continue processing tuples, same as before exception.